### PR TITLE
Release 1.1.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.radarbase"
-version = "1.1.5-SNAPSHOT"
+version = "1.1.5"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.radarbase"
-version = "1.1.5"
+version = "1.1.5-SNAPSHOT"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.radarbase"
-version = "1.1.4"
+version = "1.1.5"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/radar-spring-auth/build.gradle.kts
+++ b/radar-spring-auth/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 // Dependecy versions
-val mpVersion = "0.7.1"
+val mpVersion = "0.8.2"
 val springVersion = "5.2.4.RELEASE"
 val slf4jVersion = "1.7.30"
 val aspectJVersion = "1.9.5"


### PR DESCRIPTION
- Bumps radar-auth/mpVersion to `0.8.2` with `TokenValidator` fixes
